### PR TITLE
macro for installing config files always used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(mpi_cmake_modules REQUIRED)
 find_package(pybind11 REQUIRED)
+find_package(cmake_always_do REQUIRED)
 
 # prepare to export all needed targets
 set(all_targets)
@@ -18,23 +19,33 @@ set(all_target_exports)
 # Configuration file installation #
 ###################################
 
-# calling the "install" script, which copy all
-# configuration files to either ~/.mpi-is or
-# /opt/mpi-is (if called by root)
-execute_process(COMMAND "bash"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  INPUT_FILE install
-  TIMEOUT 5
-  RESULTS_VARIABLE install_results
-  OUTPUT_VARIABLE install_stdout
-  ERROR_VARIABLE install_stderr)
-if(${install_results} EQUAL 0)
-  message(STATUS "copied configuration files: ${install_stdout}")
-else()
-  message(FATAL_ERROR "failed to copy configuration files: ${install_stderr}")
-endif()
+macro(INSTALL_CONFIG_FILES)
 
+  # calling the "install" script, which copy all
+  # configuration files to either ~/.mpi-is or
+  # /opt/mpi-is (if called by root)
+  execute_process(COMMAND "bash"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    INPUT_FILE install
+    TIMEOUT 5
+    RESULTS_VARIABLE install_results
+    OUTPUT_VARIABLE install_stdout
+    ERROR_VARIABLE install_stderr)
+  if(${install_results} EQUAL 0)
+    message(STATUS "copied configuration files: ${install_stdout}")
+  else()
+    message(FATAL_ERROR "failed to copy configuration files: ${install_stderr}")
+  endif()
 
+  # ensuring installation if always called, despite the cache.
+  # always_do is exported by the package cmake_always_do
+  ALWAYS_DO("installing pam configuration files")
+  
+endmacro()
+
+INSTALL_CONFIG_FILES()
+
+  
 ###########
 # Library #
 ###########

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
   <license>BSD 3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>cmake_always_do</buildtool_depend>
+  <build_depend>cmake_always_do</build_depend>
 
   <depend>mpi_cmake_modules</depend>
   <depend>pybind11_vendor</depend>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <license>BSD 3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>cmake_always_do</buildtool_depend>
 
   <depend>mpi_cmake_modules</depend>
   <depend>pybind11_vendor</depend>


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The "always_do" macro (from the cmake_always_do package) is used to ensure the configuration files are installed everytime colcon built is called 

## How I Tested

Built several times locally

