### PR TITLE
Set floor and tennicam transform to match with Vicon

### DIFF
--- a/config/pam_mujoco/models/robot_templates/pamy2/body_template.xml
+++ b/config/pam_mujoco/models/robot_templates/pamy2/body_template.xml
@@ -137,7 +137,7 @@
         <site name="?id?_tendon_3_4_side_opposite_to_muscle" pos="0 0 0.0371"  type="sphere" size=".01 0 0" rgba="1 0 0 0" />
         <site name="?id?_tendon_5_base_rot_point_of_contact" pos="-0.0371 0 0.36742" type="sphere" size=".02 0 0" rgba="1 1 1 0"/>
         <site name="?id?_tendon_6_base_rot_point_of_contact" pos="0.0371 0 0.36742" type="sphere" size=".02 0 0" rgba="1 1 1 0"/>
-	<body pos="0 0 0.36742">
+        <body pos="0 0 0.36742">
           <geom name="?id?_dummy_cylinder_for_tendon_wrapping_3" type = "cylinder" size="0.037 0.01" zaxis="0 1 0" rgba="1 0 0 0" mass="0.000001"/>
           <joint type="hinge" name="?id?_dof3" axis="0 1 0"  frictionloss="7.7682"  solreffriction="0.5" solimpfriction="0.65914" limited="true" range="-89.8 89.8" solreflimit="0.003" solimplimit="1"/>
           <geom type = "mesh" mesh="igus_move" rgba = "0.20 0.20 0.20 1.0" zaxis="0 0 -1" pos = "-0.04 0.0366 0.065" mass="0.03"/>
@@ -147,7 +147,7 @@
           <site name="?id?_tendon_7_base_rot_point_of_contact" pos="0 -0.0371 0" type="sphere" size=".02 0 0" rgba="1 1 1 0"/>
           <site name="?id?_tendon_8_base_rot_point_of_contact" pos="0 0.0371 0" type="sphere" size=".02 0 0" rgba="1 1 1 0"/>
           <body pos="0 0 -0.395">
-	    <geom name="?id?_dummy_cylinder_for_tendon_wrapping_4" type = "cylinder" size="0.037 0.01" rgba="1 0 0 0" mass="0.000001"/>
+            <geom name="?id?_dummy_cylinder_for_tendon_wrapping_4" type = "cylinder" size="0.037 0.01" rgba="1 0 0 0" mass="0.000001"/>
             <joint type="hinge" name="?id?_dof4" axis="0 0 1" pos="0 0 0"  frictionloss="111.9529"  solreffriction="0.38711" solimpfriction="2.5699"  limited="true" range="-89.8 89.8" solreflimit="0.003" solimplimit="1"/>
             <geom type = "cylinder" size="0.013 0.105" pos="0 0 0.54" zaxis="0 0 1" rgba="0.95 0.95 0.95 1.0" mass="0.11402"/>
             <geom name="?id?_racket_handle" type = "mesh" mesh="schlaeger_anbindung-igus_anbindung_extra-1" rgba="0.99 0.99 0.99 1" zaxis = "0 -1 0" pos ="-0.075 0.016 0.615"  mass="0.02"/>

--- a/config/pam_mujoco/models/template.xml
+++ b/config/pam_mujoco/models/template.xml
@@ -18,7 +18,7 @@
   <worldbody>
     <light diffuse="1.5 1.5 1.5" pos="0 0 8.0" dir="0 0 -1"/>
     <light directional="true" cutoff="60" exponent="1" diffuse="0.1 0.1 0.1" specular=".1 .1 .1" pos=".1 .2 1.3" dir="-.1 -.2 -1.3"/>
-    <geom pos="0.0 0.0 0.0" name="floor" type="plane" size="3.0 3.0 0.01" rgba=".16 .15 0.20 0.9" solref="0.03 0.06"/>
+    <geom pos="0.0 0.0 -2.115" name="floor" type="plane" size="3.0 3.0 0.01" rgba=".16 .15 0.20 0.9" solref="0.03 0.06"/>
 
     <!-- bodies -->
     

--- a/config/tennicam_client/config.toml
+++ b/config/tennicam_client/config.toml
@@ -1,6 +1,7 @@
 [transform]
-translation = [0.1058,3.1864,0.453]
-rotation = [0,0,0]
+translation = [0.385887, 0.185144, -0.425765]
+# extrinsic xyz Euler angles
+rotation = [0.00499201, -0.0156143, -0.0121934]
 [server]
 hostname = "rodau"
 port = 7660


### PR DESCRIPTION
## Description

Since we want to use the ping marker as origin for the world frame in the lab, some changes are needed here:

1. Move the floor plane in the robot model down.  Distance is measured manually, so might be off a little bit but I assume this is not so critical here.
2. Set tennicam transform such that ball positions are w.r.t. the world frame.  Determined using the calibration procedure described [in the documentation](https://intelligent-soft-robots.github.io/pam_documentation/C9.1_tennicam_vicon_transform.html).


## How I Tested

Only qualitatively verified using visualisation in Mujoco:
1. Use table pose from Vicon and checked that the visualised table stands on the floor.
2. Use table pose from Vicon and ball position from tennicam and manually moved a ball along the edges of the table.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
